### PR TITLE
Support installing curator in a Python virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Install via pip
   }
 ```
 
+Install in a virtualenv via pip
+```puppet
+  class { 'curator':
+    provider        => 'virtualenv',
+    virtualenv_path => '/opt/elasticsearch-curator',
+  }
+```
+You'll need to use the include the
+[stankevich/python](https://forge.puppetlabs.com/stankevich/python)
+module in your manifests and ensure the **pip** and **virtualenv**
+parameters are set to *true*.
+
 Disable bloom filters on indexes over 2 days old
 ```puppet
   curator::job { 'logstash_bloom':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,10 +39,11 @@
 # Copyright 2014 EvenUp.
 #
 class curator (
-  $ensure       = 'latest',
-  $package_name = 'python-elasticsearch-curator',
-  $provider     = undef,
-  $manage_pip   = false
+  $ensure          = 'latest',
+  $package_name    = 'python-elasticsearch-curator',
+  $provider        = undef,
+  $virtualenv_path = '/opt/elasticsearch-curator',
+  $manage_pip      = false
 ) {
 
   if ( $ensure != 'latest' or $ensure != 'absent' ) {
@@ -51,18 +52,43 @@ class curator (
     }
   }
 
-  if $manage_pip {
-    package { 'python-pip':
-      ensure => installed,
-      before => Package['elasticsearch-curator'],
-    }
-  }
-
   case $provider {
     pip: {
+      if $manage_pip {
+        package { 'python-pip':
+          ensure => installed,
+          before => Package['elasticsearch-curator'],
+        }
+      }
       package { 'elasticsearch-curator':
         ensure   => $ensure,
         provider => pip,
+      }
+    }
+    virtualenv: {
+      validate_absolute_path($virtualenv_path)
+      if ! defined(Class['python']) {
+        fail('You must include the python class before using the curator class with provider virtualenv')
+      }
+      if ! defined('python::pip') {
+        fail ('You need to set the python::pip class parameter to true.')
+      }
+      if ! defined('python::virtualenv') {
+        fail ('You need to set the python::virtualenv class parameter to true.')
+      }
+      python::virtualenv { $virtualenv_path:
+        owner => 'root',
+        group => 'root',
+      }
+      python::pip { 'python-pip-elasticsearch':
+        pkgname    => 'elasticsearch',
+        virtualenv => $virtualenv_path,
+        owner      => 'root',
+      }
+      python::pip { 'python-pip-elasticsearch-curator':
+        pkgname    => 'elasticsearch-curator',
+        virtualenv => $virtualenv_path,
+        owner      => 'root',
       }
     }
     default: {


### PR DESCRIPTION
This pull requests adds a new provider, "virtualenv" which allows for installing curator within a Python virtualenv.  This is useful where installing curator and its dependencies conflict with distro-installed packages (i.e., conflicting versions).  

The changes make use of the [stankevich/python](https://forge.puppetlabs.com/stankevich/python) forge module and I've tried to ensure that it isn't a hard dependancy (i.e., not required if not using the virtualenv provider). 

So if you don't use the virtualenv provider, the behaviour of the module has not changed.