### PR TITLE
logfile params need to be first - per latest docs

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -238,7 +238,7 @@ define curator::job (
   $index_options = join(delete_undef_values([$_prefix, $_suffix, $_regex, $_time_unit, $_exclude, $_index, $_snapshot, $_older_than, $_newer_than, $_timestring]), ' ')
 
   cron { "curator_${name}":
-    command => "${bin_file}${mo_string} --host ${host} --port ${port} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat} ${exec} ${index_options}",
+    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat}${mo_string} --host ${host} --port ${port} ${exec} ${index_options}",
     hour    => $cron_hour,
     minute  => $cron_minute,
     weekday => $cron_weekday,

--- a/spec/defines/curator_job_spec.rb
+++ b/spec/defines/curator_job_spec.rb
@@ -134,7 +134,7 @@ describe 'curator::job', :type => :define do
      :logformat    => 'logstash',
      :master_only  => true
    } }
-   it { should contain_cron('curator_myjob').with(:command => "/bin/curator --master-only --host es.mycompany.com --port 1000 --logfile /data/curator.log --loglevel WARN --logformat logstash open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h'") }
+   it { should contain_cron('curator_myjob').with(:command => "/bin/curator --logfile /data/curator.log --loglevel WARN --logformat logstash --master-only --host es.mycompany.com --port 1000 open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h'") }
  end
 
 end


### PR DESCRIPTION
Tested change in a production env. Updated final command order. See https://www.elastic.co/guide/en/elasticsearch/client/curator/current/logfile.html

