### PR TITLE
Fix output to stdout from cron job, and fix invalid default value for --timestring

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -26,7 +26,7 @@ define curator::job (
   $older_than            = undef,
   $newer_than            = undef,
   $time_unit             = 'days',
-  $timestring            = '\%Y.\%m.\%d',
+  $timestring            = '%Y.%m.%d',
   $master_only           = false,
   $logfile               = $::curator::logfile,
   $log_level             = $::curator::log_level,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -243,7 +243,7 @@ define curator::job (
   $index_options = join(delete_undef_values([$_prefix, $_suffix, $_regex, $_time_unit, $_exclude, $_index, $_snapshot, $_older_than, $_newer_than, $_timestring]), ' ')
 
   cron { "curator_${name}":
-    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat}${mo_string} --host ${host} --port ${port} ${exec} ${index_options}",
+    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat}${mo_string} --host ${host} --port ${port} ${exec} ${index_options} >/dev/null",
     hour    => $cron_hour,
     minute  => $cron_minute,
     weekday => $cron_weekday,

--- a/spec/defines/curator_job_spec.rb
+++ b/spec/defines/curator_job_spec.rb
@@ -139,7 +139,7 @@ describe 'curator::job', :type => :define do
      :logformat    => 'logstash',
      :master_only  => true
    } }
-   it { should contain_cron('curator_myjob').with(:command => "/bin/curator --logfile /data/curator.log --loglevel WARN --logformat logstash --master-only --host es.mycompany.com --port 1000 open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h'") }
+   it { should contain_cron('curator_myjob').with(:command => "/bin/curator --logfile /data/curator.log --loglevel WARN --logformat logstash --master-only --host es.mycompany.com --port 1000 open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h' >/dev/null") }
  end
 
 end


### PR DESCRIPTION
## 1: Curator produces output to stdout for commands such as the following:

`root@server:~# curator --logfile /tmp/curator.log --loglevel ERROR delete indices --prefix logstash- --older-than 30 --time-unit days --timestring %Y.%m.%d`
**No indices matched provided args.**

This would cause email to be sent to root when run from cron.

See also
elastic/curator#428

## 2: Fix invalid format string for timestring flag

curator::job defaults the --timestring flag to '\%Y.\%m.\%d'. This is invalid (in curator 3.2, at least) as it  does not expect the % characters to escaped and so rejects them.