### PR TITLE
Fixed remove parameter in alias subcommand.

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -159,9 +159,14 @@ define curator::job (
       if !$alias_name {
         fail("curator::job[${name}] alias_name is required with alias")
       }
-      validate_bool($remove)
-
-      $exec = "alias --name ${alias_name} --remove ${remove} indices"
+      if $remove {
+        validate_bool($remove)
+        $_remove = ' --remove'
+      } else {
+        $_remove = ''
+      }
+      
+      $exec = "alias --name ${alias_name}${_remove} indices"
     }
     'allocation': {
       # allocation validations

--- a/spec/defines/curator_job_spec.rb
+++ b/spec/defines/curator_job_spec.rb
@@ -22,7 +22,7 @@ describe 'curator::job', :type => :define do
 
     context 'valid params' do
       let(:params) { { :command => 'alias', :alias_name => 'archive', :remove => true } }
-      it { should contain_cron('curator_myjob').with(:command => /alias --name archive --remove true/) }
+      it { should contain_cron('curator_myjob').with(:command => /alias --name archive --remove/) }
     end
   end
 


### PR DESCRIPTION
This pull request fixes the remove parameter in the alias subcommand. As stated in the documentation of the curator CLI (https://www.elastic.co/guide/en/elasticsearch/client/curator/current/alias.html) the remove parameter does not require a value.

As an example:
/usr/bin/curator alias --name aliasname --remove true indices --prefix 'logstash-' --time-unit days --older-than 26 --timestring '%Y.%m.%d'

Results in the following output (as for curator 3.2.3:
"Error: No such command "true"."

The command should be:
/usr/bin/curator alias --name alias --remove indices --prefix logstash-' --time-unit days --older-than 26 --timestring '%Y.%m.%d'

This pull request is a fix for that.