### PR TITLE
Add support for apt/yum repos & Shield parameters

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,8 @@
 fixtures:
   forge_modules:
+    apt:
+      repo: "puppetlabs/apt"
+      ref: "2.2.0"
     stdlib:
       repo: "puppetlabs/stdlib"
       ref: "4.2.0"

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ Boolean. Use ssl when connecting to Elasticsearch.
 
 Default: false
 
+####`ssl_validate`
+
+Boolean. Don't validate the ssl certificate
+
+Default: false
+
 ####`http_auth`
 
 Boolean. Use basic auth when connecting to Elasticsearch.

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -19,6 +19,7 @@ define curator::job (
 
   # Auth options
   $use_ssl               = false,
+  $ssl_validate          = false,
   $http_auth             = false,
   $user                  = undef,
   $password              = undef,
@@ -257,6 +258,14 @@ define curator::job (
     default => '',
   }
 
+  if $use_ssl {
+    if $ssl_validate {
+      $ssl_no_validate = ''
+    } else {
+      $ssl_no_validate = ' --ssl-no-validate'
+    }
+  }
+
   if $http_auth {
     validate_string($user)
     validate_string($password)
@@ -269,7 +278,7 @@ define curator::job (
 
   cron { "curator_${name}":
     ensure  => $ensure,
-    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat}${mo_string}${ssl_string}${auth_string} --host ${host} --port ${port} ${exec} ${index_options} >/dev/null",
+    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat}${mo_string}${ssl_string}${ssl_no_validate}${auth_string} --host ${host} --port ${port} ${exec} ${index_options} >/dev/null",
     hour    => $cron_hour,
     minute  => $cron_minute,
     weekday => $cron_weekday,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,8 @@ class curator::params {
   $ensure       = 'latest'
   $package_name = 'elasticsearch-curator'
   $provider     = 'pip'
+  $manage_repo  = false
+  $repo_version = false
 
   # Defaults used for jobs, set through the class to make it easy to override
   $bin_file     = '/bin/curator'
@@ -14,5 +16,4 @@ class curator::params {
   $logfile      = '/var/log/curator.log'
   $log_level    = 'INFO'
   $logformat    = 'default'
-
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,57 @@
+# == Class: curator::repo
+#
+# This class exists to install and manage yum and apt repositories
+# that contain official curator packages
+#
+#
+# === Parameters
+#
+# This class does not provide any parameters.
+#
+#
+# === Examples
+#
+# This class may be imported by other classes to use its functionality:
+#   class { 'curator::repo': }
+#
+# It is not intended to be used directly by external resources like node
+# definitions or other modules.
+#
+#
+# === Authors
+#
+# * Petter Abrahamsson <mailto:petter@jebus.nu>
+# * Phil Fenstermacher <mailto:phillip.fenstermacher@gmail.com>
+# * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
+#
+class curator::repo {
+
+  case $::osfamily {
+    'Debian': {
+      if !defined(Class['apt']) {
+        class { '::apt': }
+      }
+
+      apt::source { 'curator':
+        location    => "http://packages.elastic.co/curator/${curator::repo_version}/debian",
+        release     => 'stable',
+        repos       => 'main',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+        key_server  => 'pgp.mit.edu',
+        include_src => false,
+      }
+    }
+    'RedHat': {
+      yumrepo { 'curator':
+        descr    => 'Curator Centos Repo',
+        baseurl  => "http://packages.elastic.co/curator/${curator::repo_version}/centos/${::operatingsystemmajrelease}",
+        gpgcheck => 1,
+        gpgkey   => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
+        enabled  => 1,
+      }
+    }
+    default: {
+      fail("\"${module_name}\" provides no repository information for OSfamily \"${::osfamily}\"")
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,7 @@
     { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] }
   ],
   "dependencies": [
+    { "name": "puppetlabs/apt", "version_requirement": ">=2.2.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.2.0 <5.0.0" }
   ]
 }

--- a/spec/classes/curator_repo_spec.rb
+++ b/spec/classes/curator_repo_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'curator', :type => :class do
+  let(:params) {
+    {
+      :ensure       => '3.4.0',
+      :manage_repo  => true,
+      :package_name => 'python-elasticsearch-curator',
+      :repo_version => '3',
+    }
+  }
+  context 'Repo class on RedHat/CentOS' do
+    let(:facts) {
+      {
+        :osfamily => 'RedHat',
+      }
+    }
+
+    it { should create_class('curator::repo') }
+    it { should contain_yumrepo('curator').with(:baseurl => 'http://packages.elastic.co/curator/3/centos/') }
+  end
+
+  context 'Repo class on Debian/Ubuntu' do
+    let(:facts) {
+      {
+        :lsbdistid => 'Debian',
+        :osfamily  => 'Debian'
+      }
+    }
+
+    it { should create_class('curator::repo') }
+    it { should contain_apt__source('curator').with(:location => 'http://packages.elastic.co/curator/3/debian') }
+  end
+
+  context 'set package version and package name and manage repository for yum' do
+    let(:facts) {
+      {
+        :osfamily => 'RedHat',
+      }
+    }
+    it { should contain_package('python-elasticsearch-curator').with(:ensure => '3.4.0') }
+  end
+
+  context 'set package version and package name and manage repository for apt' do
+    let(:facts) {
+      {
+        :lsbdistid => 'Debian',
+        :osfamily  => 'Debian',
+      }
+    }
+    it { should contain_package('python-elasticsearch-curator').with(:ensure => '3.4.0') }
+  end
+end

--- a/spec/defines/curator_job_spec.rb
+++ b/spec/defines/curator_job_spec.rb
@@ -9,6 +9,11 @@ describe 'curator::job', :type => :define do
     it { expect { should raise_error(Puppet::Error) } }
   end
 
+  context 'port is valid' do
+    let(:params) { { :port => 'string' } }
+    it { expect { should raise_error(Puppet::Error) } }
+  end
+
   context 'ensure absent' do
     let(:params) { { :command => 'alias', :alias_name => 'archive', :ensure => 'absent' } }
     it { should contain_cron('curator_myjob').with(:ensure => 'absent') }
@@ -140,6 +145,11 @@ describe 'curator::job', :type => :define do
       it { should contain_cron('curator_myjob').with(:command => /--use_ssl/) }
     end
 
+    context 'ssl_validate' do
+      let(:params) { { :command => 'snapshot', :repository => 'archive', :use_ssl => true, :ssl_validate => false } }
+      it { should contain_cron('curator_myjob').with(:command => /--use_ssl --ssl-no-validate/) }
+    end
+
     context 'valid params' do
       let(:params) { { :command => 'snapshot', :repository => 'archive' } }
       it { should contain_cron('curator_myjob').with(:command => /snapshot --repository archive/) }
@@ -159,11 +169,12 @@ describe 'curator::job', :type => :define do
      :logformat    => 'logstash',
      :master_only  => true,
      :use_ssl      => true,
+     :ssl_validate => false,
      :http_auth    => true,
      :user         => 'user',
      :password     => 'password'
    } }
-   it { should contain_cron('curator_myjob').with(:command => "/bin/curator --logfile /data/curator.log --loglevel WARN --logformat logstash --master-only --use_ssl --http_auth user:password --host es.mycompany.com --port 1000 open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h' >/dev/null") }
+   it { should contain_cron('curator_myjob').with(:command => "/bin/curator --logfile /data/curator.log --loglevel WARN --logformat logstash --master-only --use_ssl --ssl-no-validate --http_auth user:password --host es.mycompany.com --port 1000 open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h' >/dev/null") }
  end
 
 end


### PR DESCRIPTION
This adds support for using the official apt/yum repos (copied from [elasticsearch/puppet-logstash](https://github.com/elasticsearch/puppet-logstash)).
It also exposes a few additional parameters necessary for Shield.