### PR TITLE
Added cron email address parameter to job

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,11 @@ Cron.  Minute of the hour to schedule the cron entry
 
 Default: 10
 
+#####`cron_email`
+
+Cron. Set the email address MAILTO field for the errors from the cron job
+
+Default: undef
 
 ### Private classes
 

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -62,6 +62,7 @@ define curator::job (
   $cron_weekday          = '*',
   $cron_hour             = 1,
   $cron_minute           = 10,
+  $cron_email            = undef,
 ){
 
   include ::curator
@@ -280,15 +281,22 @@ define curator::job (
     $auth_string = undef
   }
 
+  if $cron_email {
+    $cron_environment = "MAILTO=${cron_email}"
+  } else {
+    $cron_environment = undef
+  }
+
   $index_options = join(delete_undef_values([$_prefix, $_suffix, $_regex, $_time_unit, $_exclude, $_index, $_snapshot, $_older_than, $_newer_than, $_timestring]), ' ')
   $options = join(delete_undef_values([$mo_string, $ssl_string, $ssl_certificate, $ssl_no_validate, $auth_string]), ' ')
 
   cron { "curator_${name}":
-    ensure  => $ensure,
-    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat} ${options} --host ${host} --port ${port} ${exec} ${index_options} >/dev/null",
-    hour    => $cron_hour,
-    minute  => $cron_minute,
-    weekday => $cron_weekday,
+    ensure      => $ensure,
+    command     => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat} ${options} --host ${host} --port ${port} ${exec} ${index_options} >/dev/null",
+    hour        => $cron_hour,
+    minute      => $cron_minute,
+    weekday     => $cron_weekday,
+    environment => $cron_environment,
   }
 
 }

--- a/spec/defines/curator_job_spec.rb
+++ b/spec/defines/curator_job_spec.rb
@@ -156,6 +156,16 @@ describe 'curator::job', :type => :define do
     end
   end
 
+  context 'not setting email' do
+    let (:params) {{:command => 'snapshot', :repository => 'archive'}}
+    it { should contain_cron('curator_myjob').with(:environment => nil)}
+  end
+
+  context 'setting email' do
+    let (:params) {{:command => 'snapshot', :repository => 'archive', :cron_email => 'admin@example.com'}}
+    it { should contain_cron('curator_myjob').with(:environment => 'MAILTO=admin@example.com')}
+  end
+
   context 'set all other params' do
     let(:params) do
       {


### PR DESCRIPTION
This adds the parameter $cron_email to the job define allowing you to control where the emails get sent to from the crontab failures.
