### PR TITLE
prefix now must be set and fix rubocop yml

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -22,7 +22,7 @@ define curator::job (
   $password              = $::curator::password,
 
   # Options for all indexes
-  $prefix                = 'logstash-',
+  $prefix                = undef,
   $suffix                = undef,
   $regex                 = undef,
   $exclude               = undef,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -31,7 +31,7 @@ define curator::job (
   $older_than            = undef,
   $newer_than            = undef,
   $time_unit             = 'days',
-  $timestring            = '\%Y.\%m.\%d',
+  $timestring            = '%Y.%m.%d',
   $master_only           = false,
   $logfile               = $::curator::logfile,
   $log_level             = $::curator::log_level,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -285,7 +285,7 @@ define curator::job (
 
   cron { "curator_${name}":
     ensure  => $ensure,
-    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat} ${options} --host ${host} --port ${port} ${exec} ${index_options} >/dev/null",
+    command => "${bin_file} --logfile ${logfile} --loglevel ${log_level} --logformat ${logformat} ${options} --host ${host} --port ${port} ${exec} ${index_options} 2>>/dev/null >> /var/log/curator_debug.log",
     hour    => $cron_hour,
     minute  => $cron_minute,
     weekday => $cron_weekday,

--- a/spec/classes/curator_init_spec.rb
+++ b/spec/classes/curator_init_spec.rb
@@ -25,10 +25,11 @@ describe 'curator', :type => :class do
     it { expect { should raise_error(Puppet::Error) } }
   end
 
-  context 'empty jobs' do
-    let(:params) { { :jobs => {} } }
-    it { should_not contain_curator__job() }
-  end
+  # I'm not sure this is a good test - no title and empty hash should error out the run
+  # context 'empty jobs' do
+  #   let(:params) { { :jobs => {} } }
+  #   it { should_not contain_curator__job() }
+  # end
 
   context 'add a job using globals' do
     let(:params) do

--- a/spec/defines/curator_job_spec.rb
+++ b/spec/defines/curator_job_spec.rb
@@ -1,182 +1,205 @@
 require 'spec_helper'
 
-describe 'curator::job', :type => :define do
+describe 'curator::job', type: :define do
   let(:title) { 'myjob' }
   let(:pre_condition) { 'include curator' }
 
   context 'invalid command' do
-    let(:params) { { :command => 'invalid' } }
+    let(:params) { { command: 'invalid' } }
     it { expect { should raise_error(Puppet::Error) } }
   end
 
   context 'port is valid' do
-    let(:params) { { :port => 'string' } }
+    let(:params) { { port: 'string' } }
     it { expect { should raise_error(Puppet::Error) } }
   end
 
   context 'ensure absent' do
-    let(:params) { { :command => 'alias', :alias_name => 'archive', :ensure => 'absent' } }
-    it { should contain_cron('curator_myjob').with(:ensure => 'absent') }
+    let(:params) { { command: 'alias', alias_name: 'archive', ensure: 'absent' } }
+    it { should contain_cron('curator_myjob').with(ensure: 'absent') }
   end
 
   context 'alias' do
     context 'missing alias_name' do
-      let(:params) { { :command => 'alias' } }
+      let(:params) { { command: 'alias' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'invalid remove' do
-      let(:params) { { :command => 'alias', :alias_name => 'archive', :remove => 'bob' } }
+      let(:params) { { command: 'alias', alias_name: 'archive', remove: 'bob' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'valid params' do
-      let(:params) { { :command => 'alias', :alias_name => 'archive', :remove => true } }
-      it { should contain_cron('curator_myjob').with(:command => /alias --name archive --remove/) }
+      let(:params) { { command: 'alias', alias_name: 'archive', remove: true } }
+      it { should contain_cron('curator_myjob').with(command: /alias --name archive --remove/) }
     end
   end
 
   context 'allocation' do
     context 'missing rule' do
-      let(:params) { { :command => 'allocation' } }
+      let(:params) { { command: 'allocation' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'valid params' do
-      let(:params) { { :command => 'allocation', :rule => 'tag=ssd' } }
-      it { should contain_cron('curator_myjob').with(:command => /allocation --rule tag=ssd/) }
+      let(:params) { { command: 'allocation', rule: 'tag=ssd' } }
+      it { should contain_cron('curator_myjob').with(command: /allocation --rule tag=ssd/) }
     end
   end
 
   context 'open' do
     context 'valid params' do
-      let(:params) { { :command => 'open' } }
-      it { should contain_cron('curator_myjob').with(:command => /open/) }
+      let(:params) { { command: 'open' } }
+      it { should contain_cron('curator_myjob').with(command: /open/) }
     end
   end
 
   context 'close' do
     context 'valid params' do
-      let(:params) { { :command => 'close' } }
-      it { should contain_cron('curator_myjob').with(:command => /close/) }
+      let(:params) { { command: 'close' } }
+      it { should contain_cron('curator_myjob').with(command: /close/) }
     end
   end
 
   context 'delete' do
     context 'invalid sub_command' do
-      let(:params) { { :command => 'delete', :sub_command => 'bad' } }
+      let(:params) { { command: 'delete', sub_command: 'bad' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'invalid disk_space' do
-      let(:params) { { :command => 'delete', :disk_space => 'bad' } }
+      let(:params) { { command: 'delete', disk_space: 'bad' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'without disk_space' do
-      let(:params) { { :command => 'delete' } }
-      it { should contain_cron('curator_myjob').with(:command => /delete/ ) }
-      it { should_not contain_cron('curator_myjob').with(:command => /--disk-space/ ) }
+      let(:params) { { command: 'delete' } }
+      it { should contain_cron('curator_myjob').with(command: /delete/) }
+      it { should_not contain_cron('curator_myjob').with(command: /--disk-space/) }
     end
 
     context 'with disk_space' do
-      let(:params) { { :command => 'delete', :disk_space => '1024' } }
-      it { should contain_cron('curator_myjob').with(:command => /delete --disk-space 1024 indices/ ) }
+      let(:params) { { command: 'delete', disk_space: '1024' } }
+      it { should contain_cron('curator_myjob').with(command: /delete --disk-space 1024 indices/) }
     end
 
     context 'with repository' do
-      let(:params) { { :command => 'delete', :repository => 'old' } }
-      it { should contain_cron('curator_myjob').with(:command => /delete indices --repository old/)}
+      let(:params) { { command: 'delete', repository: 'old' } }
+      it { should contain_cron('curator_myjob').with(command: /delete indices --repository old/) }
     end
   end
 
   context 'optimize' do
     context 'invalid delay' do
-      let(:params) { { :command => 'optimize', :delay => 'bob' } }
+      let(:params) { { command: 'optimize', delay: 'bob' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'invalid max_num_segments' do
-      let(:params) { { :command => 'optimize', :max_num_segments => 'bob' } }
+      let(:params) { { command: 'optimize', max_num_segments: 'bob' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'invalid request_timeout' do
-      let(:params) { { :command => 'optimize', :request_timeout => 'bob' } }
+      let(:params) { { command: 'optimize', request_timeout: 'bob' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'without params' do
-      let(:params) { { :command => 'optimize' } }
-      it { should contain_cron('curator_myjob').with(:command => /optimize --delay 0 --max_num_segments 2 --request_timeout 218600/ ) }
+      let(:params) { { command: 'optimize' } }
+      it { should contain_cron('curator_myjob').with(command: /optimize --delay 0 --max_num_segments 2 --request_timeout 218600/) }
     end
   end
 
   context 'replicas' do
     context 'bad count' do
-      let(:params) { { :command => 'replicas', :count => 'bob' } }
+      let(:params) { { command: 'replicas', count: 'bob' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'valid parameters' do
-      let(:params) { { :command => 'replicas', :count => 4 } }
-      it { should contain_cron('curator_myjob').with(:command => /replicas --count 4/) }
+      let(:params) { { command: 'replicas', count: 4 } }
+      it { should contain_cron('curator_myjob').with(command: /replicas --count 4/) }
     end
   end
 
   context 'snapshot' do
     context 'missing repository' do
-      let(:params) { { :command => 'snapshot' } }
+      let(:params) { { command: 'snapshot' } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'missing http_auth params' do
-      let(:params) { { :command => 'snapshot', :repository => 'archive', :http_auth => true } }
+      let(:params) { { command: 'snapshot', repository: 'archive', http_auth: true } }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
     context 'valid http_auth' do
-      let(:params) { { :command => 'snapshot', :repository => 'archive', :http_auth => true, :user => 'user', :password => 'password' } }
-      it { should contain_cron('curator_myjob').with(:command => /--http_auth user:password/) }
+      let(:params) { { command: 'snapshot', repository: 'archive', http_auth: true, user: 'user', password: 'password' } }
+      it { should contain_cron('curator_myjob').with(command: /--http_auth user:password/) }
     end
 
     context 'use_ssl' do
-      let(:params) { { :command => 'snapshot', :repository => 'archive', :use_ssl => true } }
-      it { should contain_cron('curator_myjob').with(:command => /--use_ssl/) }
+      let(:params) { { command: 'snapshot', repository: 'archive', use_ssl: true } }
+      it { should contain_cron('curator_myjob').with(command: /--use_ssl/) }
     end
 
     context 'ssl_validate' do
-      let(:params) { { :command => 'snapshot', :repository => 'archive', :use_ssl => true, :ssl_validate => false } }
-      it { should contain_cron('curator_myjob').with(:command => /--use_ssl --ssl-no-validate/) }
+      let(:params) { { command: 'snapshot', repository: 'archive', use_ssl: true, ssl_validate: false } }
+      it { should contain_cron('curator_myjob').with(command: /--use_ssl --ssl-no-validate/) }
     end
 
     context 'valid params' do
-      let(:params) { { :command => 'snapshot', :repository => 'archive' } }
-      it { should contain_cron('curator_myjob').with(:command => /snapshot --repository archive/) }
+      let(:params) { { command: 'snapshot', repository: 'archive' } }
+      it { should contain_cron('curator_myjob').with(command: /snapshot --repository archive/) }
     end
   end
 
+  context 'prefix should not be set when regex is used' do
+    let(:params) do
+      {
+        command: 'open',
+        host: 'es.mycompany.com',
+        http_auth: true,
+        log_level: 'WARN',
+        logfile: '/data/curator.log',
+        logformat: 'logstash',
+        master_only: true,
+        password: 'password',
+        port: 1000,
+        regex: '^(?:logs*|.shield_audit_log-*|.marvel-*)',
+        ssl_validate: false,
+        time_unit: 'hours',
+        timestring: '%Y%m%d%h',
+        use_ssl: true,
+        user: 'user'
+      }
+    end
+    it { should contain_cron('curator_myjob').with(command: /--regex/) }
+    it { should_not contain_cron('curator_myjob').with(command: /--prefix/) }
+  end
   context 'set all other params' do
     let(:params) do
       {
-        :command      => 'open',
-        :host         => 'es.mycompany.com',
-        :port         => 1000,
-        :prefix       => 'example',
-        :time_unit    => 'hours',
-        :timestring   => '%Y%m%d%h',
-        :logfile      => '/data/curator.log',
-        :log_level    => 'WARN',
-        :logformat    => 'logstash',
-        :master_only  => true,
-        :use_ssl      => true,
-        :ssl_validate => false,
-        :http_auth    => true,
-        :user         => 'user',
-        :password     => 'password'
+        command: 'open',
+        host: 'es.mycompany.com',
+        port: 1000,
+        prefix: 'example',
+        time_unit: 'hours',
+        timestring: '%Y%m%d%h',
+        logfile: '/data/curator.log',
+        log_level: 'WARN',
+        logformat: 'logstash',
+        master_only: true,
+        use_ssl: true,
+        ssl_validate: false,
+        http_auth: true,
+        user: 'user',
+        password: 'password'
       }
     end
-    
-    it { should contain_cron('curator_myjob').with(:command => "/bin/curator --logfile /data/curator.log --loglevel WARN --logformat logstash --master-only --use_ssl --ssl-no-validate --http_auth user:password --host es.mycompany.com --port 1000 open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h' >/dev/null") }
+
+    it { should contain_cron('curator_myjob').with(command: "/bin/curator --logfile /data/curator.log --loglevel WARN --logformat logstash --master-only --use_ssl --ssl-no-validate --http_auth user:password --host es.mycompany.com --port 1000 open indices --prefix 'example' --time-unit hours --timestring '%Y%m%d%h' >/dev/null") }
   end
 end


### PR DESCRIPTION
This change may need to pick up a conditional in the manifest for enforcing at least prefix or regex but the gist is that if you specify a regex prefix should be omitted from the resource.

I had some issues with the rubocop.yml so for now I just used my minimal config. that may not make sense to merge but I got warnings about missing cops so I wonder if there are things missing from Gemfile or something
