### PR TITLE
Added Support for RHEL7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,7 +104,7 @@ class curator (
       ensure   => $ensure,
       provider => $_provider,
     }
-    if ( $package_dependencies and $_provider == 'yum' ) {
+    if ( $package_dependencies != undef and $_provider == 'yum' ) {
       package { $package_dependencies:
         ensure   => $ensure,
         provider => $_provider,
@@ -115,7 +115,7 @@ class curator (
       ensure   => $ensure,
       provider => $_provider,
     }
-    if ( $package_dependencies and $_provider == 'yum' ) {
+    if ( $package_dependencies != undef and $_provider == 'yum' ) {
       package { python-setuptools:
         ensure   => $ensure,
         provider => $_provider,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,8 +75,8 @@ class curator (
           $_provider     = 'apt'
         }
         'RedHat': {
-            $_package_name = 'python-elasticsearch-curator'
-            $_provider     = 'yum'
+          $_package_name = 'python-elasticsearch-curator'
+          $_provider     = 'yum'
         }
         default: {
           $_package_name = 'elasticsearch-curator'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,13 +74,8 @@ class curator (
           $_provider     = 'apt'
         }
         'RedHat': {
-          if ( $::osrelasemajor == '7' ) {
-            $_package_name = 'elastic-curator'
-            $_provider     = 'yum'
-          } else {
             $_package_name = 'python-elasticsearch-curator'
             $_provider     = 'yum'
-          }
         }
         default: {
           $_package_name = 'elasticsearch-curator'
@@ -108,7 +103,7 @@ class curator (
       ensure   => $ensure,
       provider => $_provider,
     }
-    if ( $::osfamily == 'RedHat' and $::osrelasemajor == '7' and $_provider == 'yum' ) {
+    if ( $::osfamily == 'RedHat' and $::osreleasemajor == '7' and $_provider == 'yum' ) {
       package { python-setuptools:
         ensure   => $ensure,
         provider => $_provider,
@@ -119,7 +114,7 @@ class curator (
       ensure   => $ensure,
       provider => $_provider,
     }
-    if ( $::osfamily == 'RedHat' and $::osrelasemajor == '7' and $_provider == 'yum' ) {
+    if ( $::osfamily == 'RedHat' and $::osreleasemajor == '7' and $_provider == 'yum' ) {
       package { python-setuptools:
         ensure   => $ensure,
         provider => $_provider,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,7 @@ class curator (
   $logformat            = $::curator::params::logformat,
   $manage_repo          = $::curator::params::manage_repo,
   $repo_version         = $::curator::params::repo_version,
+  $package_dependencies = $::curator::params::package_dependencies,
 ) inherits curator::params {
 
   if ( $ensure != 'latest' or $ensure != 'absent' ) {
@@ -103,8 +104,8 @@ class curator (
       ensure   => $ensure,
       provider => $_provider,
     }
-    if ( $::osfamily == 'RedHat' and $::osreleasemajor == '7' and $_provider == 'yum' ) {
-      package { python-setuptools:
+    if ( $package_dependencies and $_provider == 'yum' ) {
+      package { $package_dependencies:
         ensure   => $ensure,
         provider => $_provider,
       }
@@ -114,7 +115,7 @@ class curator (
       ensure   => $ensure,
       provider => $_provider,
     }
-    if ( $::osfamily == 'RedHat' and $::osreleasemajor == '7' and $_provider == 'yum' ) {
+    if ( $package_dependencies and $_provider == 'yum' ) {
       package { python-setuptools:
         ensure   => $ensure,
         provider => $_provider,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,8 +74,13 @@ class curator (
           $_provider     = 'apt'
         }
         'RedHat': {
-          $_package_name = 'python-elasticsearch-curator'
-          $_provider     = 'yum'
+          if ( $::osrelasemajor == '7' ) {
+            $_package_name = 'elastic-curator'
+            $_provider     = 'yum'
+          } else {
+            $_package_name = 'python-elasticsearch-curator'
+            $_provider     = 'yum'
+          }
         }
         default: {
           $_package_name = 'elasticsearch-curator'
@@ -103,10 +108,22 @@ class curator (
       ensure   => $ensure,
       provider => $_provider,
     }
+    if ( $::osfamily == 'RedHat' and $::osrelasemajor == '7' and $_provider == 'yum' ) {
+      package { python-setuptools:
+        ensure   => $ensure,
+        provider => $_provider,
+      }
+    } 
   } else {
     package { $_package_name:
       ensure   => $ensure,
       provider => $_provider,
     }
+    if ( $::osfamily == 'RedHat' and $::osrelasemajor == '7' and $_provider == 'yum' ) {
+      package { python-setuptools:
+        ensure   => $ensure,
+        provider => $_provider,
+      }
+    } 
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,8 +8,11 @@ class curator::params {
   $provider     = 'pip'
   $manage_repo  = false
   $repo_version = false
+  
   if ( $::osfamily == 'RedHat' and $::osreleasemajor == '7') {
     $package_dependencies = 'python-setuptools'
+  } else {
+    $package_dependencies = undef
   }
 
   # Defaults used for jobs, set through the class to make it easy to override

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class curator::params {
   $manage_repo  = false
   $repo_version = false
   
-  if ( $::osfamily == 'RedHat' and $::osreleasemajor == '7') {
+  if(($facts['os']['distro']['release']['major']+0)>6)and($facts['os']['family']=="RedHat") {
     $package_dependencies = 'python-setuptools'
   } else {
     $package_dependencies = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,9 @@ class curator::params {
   $provider     = 'pip'
   $manage_repo  = false
   $repo_version = false
+  if ( $::osfamily == 'RedHat' and $::osreleasemajor == '7') {
+    $package_dependencies = 'python-setuptools'
+  }
 
   # Defaults used for jobs, set through the class to make it easy to override
   $bin_file             = '/bin/curator'


### PR DESCRIPTION
For Rhel7 yum installation we also need python-setuptools as dependency.
Have a look at: https://github.com/elastic/curator/issues/454
for more information.